### PR TITLE
fix: update URLs in README and GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -37,11 +37,9 @@ jobs:
       - name: Build for GitHub Pages
         env:
           DEPLOY_TARGET: github-pages
-          BASE_PATH: /${{ github.event.repository.name }}
-          SITEMAP_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
+          SITEMAP_BASE_URL: https://${{ github.repository_owner }}.github.io
         run: |
           npm run build
-          node scripts/apply-basepath.js "/${{ github.event.repository.name }}"
           npm run sitemap
 
       - name: Upload artifact

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
-[URL_TW7]:<https://taraswww777.dev>
+[URL_TW7]:<https://taraswww777.github.io>
 
-[URL_TW7_ISSUES]:<https://github.com/taraswww777/taraswww777.dev/issues>
+[URL_TW7_ISSUES]:<https://github.com/taraswww777/taraswww777.github.io/issues>
 
-# Исходный код сайта [taraswww777.dev][URL_TW7]
+# Исходный код сайта [taraswww777.github.io][URL_TW7]
 
 ## Режим разработки
 
@@ -17,7 +17,7 @@
 Сайт сделан на подобии [brushed](https://demo.html5xcss3.com/tintin2/alessioatzeni/brushed/index.html)
 
 ## Рекомендуемые инструменты
-- репозиторий - [github.com/taraswww777](https://github.com/taraswww777/taraswww777.dev)
+- репозиторий - [github.com/taraswww777](https://github.com/taraswww777/taraswww777.github.io)
 - Проверка орфографии - [text.ru](https://text.ru/spelling)
 - Оптимизация картинок - [tinypng.com](https://tinypng.com)
 - Анализ производительности - [pagespeed.web.dev](https://pagespeed.web.dev/analysis/https-taraswww777-dev/5v61by0dey?form_factor=mobile)


### PR DESCRIPTION
- Changed the deployment URLs in the README to reflect the new GitHub Pages site.
- Updated the SITEMAP_BASE_URL in the GitHub Pages deployment workflow to remove the repository name from the base path.