### PR TITLE
chore: update project references to GitHub Pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .env
 !.idea/vcs.xml
 !.idea/taraswww777.dev.iml
+!.idea/taraswww777.github.io.iml
 !.idea/modules.xml
 .next
 # See http://help.github.com/ignore-files/ for more about ignoring files.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "taraswww777_dev_fe",
+  "name": "taraswww777.github.io",
   "version": "1.0.1",
-  "description": "Site Taras Kovalev (taraswww777). U can see taraswww777.dev",
+  "description": "Site Taras Kovalev (taraswww777). U can see taraswww777.github.io",
   "scripts": {
     "dev": "next dev",
     "build": "next build && node scripts/postbuild-exclude-admin.js",

--- a/scripts/sitemap-generator.js
+++ b/scripts/sitemap-generator.js
@@ -9,7 +9,7 @@ const sitemapConfig = {
   /** Вы можете добавить альтернативные домены, соответствующие доступному языку. (OPTIONAL) */
   // alternateUrls?: object;
   /** URL-адрес, который будет использоваться в начале каждой страницы. */
-  baseUrl: process.env.SITEMAP_BASE_URL || "https://taraswww777.dev",
+  baseUrl: process.env.SITEMAP_BASE_URL || "taraswww777.github.io",
   /** Файл или каталог, которые не следует сопоставлять (например, маршруты администратора). (OPTIONAL)*/
   ignoredPaths: ['admin', 'admin.html'],
   /** Массив дополнительных путей для включения в карту сайта (даже если они отсутствуют в PageDirectory). (OPTIONAL) */

--- a/src/constants/common.tsx
+++ b/src/constants/common.tsx
@@ -1,5 +1,5 @@
-export const SITE_NAME = 'taraswww777.dev';
-export const SITE_URL = 'https://taraswww777.dev';
+export const SITE_NAME = 'taraswww777';
+export const SITE_URL = 'https://taraswww777.github.io';
 /** Неразрывный пробел */
 export const NON_BREAKING_SPACE = ' ';
 

--- a/src/pageParts/WorkExperiencePart/__data/workExperience/Taraswww777_2022_01.tsx
+++ b/src/pageParts/WorkExperiencePart/__data/workExperience/Taraswww777_2022_01.tsx
@@ -4,8 +4,8 @@ import { FaIcon } from '../../../../ui/FaIcon';
 export const Taraswww777_2022_02: WorkExperienceDto = {
   "dateBegin": "2022-02-24T01:00:00.000Z",
   "companyName": "taraswww777",
-  "companySite": "https://taraswww777.dev/",
-  "companySiteName": "taraswww777.dev",
+  "companySite": "https://taraswww777.github.io/",
+  "companySiteName": "taraswww777",
   "workPosition": "Сам себе хозяин",
   "technologiesTags": [
     "Javascript", "React", "Typescript", "HTML5", 'PostCss', "CSS3", "webpack", 'swc',


### PR DESCRIPTION
- Changed project name and description in package.json to reflect the new GitHub Pages site.
- Updated base URL in sitemap generator and constants to point to the GitHub Pages domain.
- Modified work experience data to reference the new company site URL.